### PR TITLE
Feature/bounded depth

### DIFF
--- a/grid/eval.rkt
+++ b/grid/eval.rkt
@@ -94,7 +94,10 @@ TODO
 
 ;; get-racket-builtin : symbol? -> procedure?
 (define (get-racket-builtin f)
-  (cdr (assoc f racket-builtins)))
+  (let ((builtin (assoc f racket-builtins)))
+    (if builtin
+        (cdr builtin)
+        (raise-argument-error 'get-racket-builtin "builtin" f))))
 
 ;; unmaybe : atomic-value? -> atomic-value?
 ;; Replace 'nothing with 0, otherwise return the argument
@@ -121,9 +124,19 @@ TODO
   (cell-value-return
    (array-all-fold (array-map unmaybe (cell-value-elements vs)) op x0)))
 
+(define (if-fn test then else)
+  (if test then else))
+
+
 (define builtin-sum       (builtin-fold   + 0))
 (define builtin-max       (builtin-fold   max 'nothing))
 (define builtin-min       (builtin-fold   min 'nothing))
+
+(define builtin-=         (builtin-binary =))
+(define builtin-<         (builtin-binary <))
+(define builtin-<=        (builtin-binary <=))
+(define builtin->         (builtin-binary >))
+(define builtin->=        (builtin-binary >=))
 
 (define builtin-+         (builtin-binary +))
 (define builtin-*         (builtin-binary *))
@@ -152,12 +165,25 @@ TODO
 ;; "builtin-random" defined separately since it is the only "nullary" builtin
 (define (builtin-random) (cell-value-return (random)))
 
+(define (builtin-if test then else)
+  (cell-value-return (if-fn (unmaybe (atomise test))
+                            (unmaybe (atomise then))
+                            (unmaybe (atomise else)))))
+
+(define (builtin-halt)
+  (cell-value-return +nan.0))
 
 (define racket-builtins
   `([+         . ,builtin-+        ]
     [*         . ,builtin-*        ]
     [max       . ,builtin-max      ]
     [min       . ,builtin-min      ]
+
+    [=         . ,builtin-=        ]
+    [<         . ,builtin-<        ]
+    [<=        . ,builtin-<=       ]
+    [>         . ,builtin->        ]
+    [>=        . ,builtin->=       ]
     
     [-         . ,builtin--        ]
     [/         . ,builtin-/        ]
@@ -180,8 +206,8 @@ TODO
     [atan      . ,builtin-atan     ]
     [sqrt      . ,builtin-sqrt     ]
     [exp       . ,builtin-exp      ]
-    [random    . ,builtin-random   ]))
+    [random    . ,builtin-random   ]
 
-
-
-
+    [if        . ,builtin-if       ]
+    
+    [halt      . ,builtin-halt     ]))

--- a/stack-lang/main.rkt
+++ b/stack-lang/main.rkt
@@ -107,7 +107,7 @@
 ;;
 (define (vector-format a)
   (let ((format-elt (lambda (x)
-                      (if (number? x)
+                      (if (rational? x)
                           (~a (~r x #:min-width 9 #:precision 4)
                               #:width 10 #:align 'right)
                           (~a x #:width 10)))))
@@ -120,20 +120,20 @@
          (name-fmt    (map (compose ~a name) stack))
          (id-fmt      (map (compose ~a id) stack))
          (val-fmt     (map (compose vector-format val) stack))
-         (expr-fmt    (map (compose ~a expr) stack))
+         (expr-fmt    (map (compose (λ (e) (let ((e* (if (pair? e) (cons (caar e) (cdr e)) e))) (~a e*))) expr) stack))
          (calls-width (apply max (map string-length calls-fmt)))
          (name-width  (apply max (map string-length name-fmt)))
          (id-width    (apply max (map string-length id-fmt)))
          (val-width   (apply max (map string-length val-fmt)))
          (expr-width  (apply max (map string-length expr-fmt))))
     (display
-     (foldl (lambda (c n k v e acc)
+     (foldl (lambda (n k v e acc)
               (string-append
-               (format "~a ~a ~a | ~a | ~a~%"
-                       (~a c #:min-width calls-width)
+               (format "~a ~a | ~a | ~a~%"
+                       ;(~a c #:min-width calls-width)
                        (~a n #:min-width name-width)
                        (~a k #:min-width id-width)
                        (~a e #:min-width expr-width)
                        (~a v #:min-width val-width))
                acc))
-            "" calls-fmt name-fmt id-fmt val-fmt expr-fmt))))
+            "" name-fmt id-fmt val-fmt expr-fmt))))


### PR DESCRIPTION
## Introduce a bound on call depth; `if` and `if*` as control flow operators

- the depth is controlled by a parameter `current-stack-depth` (not yet
  exposed in lang nocell)

- depth only counts functions defined with `define-stack-fn`, and not those
  defined with `define-primitive-stack-fn`

- `if` is a function that records both branches on the stack and selects
  the top of the true branch as its value.

- `if*` records the true branch on the stack (only).